### PR TITLE
Overwrite directions link with actual directions link

### DIFF
--- a/update.js
+++ b/update.js
@@ -11,6 +11,10 @@ async function run () {
   const data = await page.evaluate(
     () => centres
   )
+  data.forEach((center, key) => {
+  	// Overwrite directions link with actual directions link
+  	center.directionsLink = `https://www.google.com/maps/dir//` + center.latitude + `,` + center.longitude + `/@` + center.latitude + `,` + center.longitude + `,14z`
+  });
   fs.writeFileSync('data.js', `
     lastUpdated = '${new Date().toString()}'
     centers = ${JSON.stringify(data)}


### PR DESCRIPTION
Hi @freeall 

This will actually use the correct directions link.

Old link:
https://www.google.com/maps/place/55.5620981,10.09875134

New link:
https://www.google.com/maps/dir//55.5620981,10.09875134/@55.5620981,10.09875134,14z

With zoom level of 14.

Next up could be to make the address clickable with the old link so you can see other data about the location.